### PR TITLE
debian: Don't replace elementary-default-settings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,7 @@ Package: plymouth-theme-elementary
 Architecture: all
 Depends: ${misc:Depends}, plymouth, plymouth-label
 Provides: plymouth-theme
-Breaks: plymouth-theme-elementary (<< 5.9.0)
-Replaces: plymouth-theme-elementary (<< 5.9.0), plymouth (<< 0.8.1-1~)
+Replaces: plymouth (<< 0.8.1-1~)
 Description: graphical boot animation and logger
  Plymouth is an application that runs very early in the boot process
  (even before the root filesystem is mounted!) that provides a graphical

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Package: plymouth-theme-elementary
 Architecture: all
 Depends: ${misc:Depends}, plymouth, plymouth-label
 Provides: plymouth-theme
-Breaks: elementary-default-settings (<<5.9.0)
-Replaces: elementary-default-settings (<<5.9.0), plymouth (<< 0.8.1-1~)
+Breaks: plymouth-theme-elementary (<< 5.9.0)
+Replaces: plymouth-theme-elementary (<< 5.9.0), plymouth (<< 0.8.1-1~)
 Description: graphical boot animation and logger
  Plymouth is an application that runs very early in the boot process
  (even before the root filesystem is mounted!) that provides a graphical


### PR DESCRIPTION
Even though both new 5.9.0 packages are now built in the PPA, `apt` still wants to remove `elementary-default-settings` to install `plymouth-theme-elementary`.

I feel like we probably didn't need `Breaks` or `Replaces` at all because the package name is still the same, we've just moved it to a different source package. Local builds with these changes work correctly on my machine.