### PR TITLE
Require meson >= 1.3.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: elementary OS Team <builds@elementary.io>
 Build-Depends:
     debhelper (>= 10.5.1),
-    meson
+    meson (>= 1.3.0)
 Standards-Version: 4.5.0
 
 Package: plymouth-theme-elementary

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project(
     'io.elementary.plymouth-theme',
-    version: '6.0.0'
+    version: '6.0.0',
+    meson_version: '>= 1.3.0'
 )
 
 install_subdir(


### PR DESCRIPTION
Because of the follow_symlinks argument in install_subdir()

https://mesonbuild.com/Reference-manual_functions.html#install_subdir_follow_symlinks

---

I noticed this because the daily recipe of plymouth-theme fails in Jammy:

https://code.launchpad.net/~elementary-os/+archive/ubuntu/daily/+build/30643503

Our development target is now Noble, so I dropped Jammy from the above recipe.
