### PR TITLE
postinst: Do not use initramfs.conf

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -26,7 +26,6 @@ case "$1" in
 
 	if which update-initramfs >/dev/null 2>&1
 	then
-        echo FRAMEBUFFER=y | tee /etc/initramfs-tools/conf.d/splash
 	    update-initramfs -u
 	fi
 	;;


### PR DESCRIPTION
Fixes #34

"/etc/initramfs-tools/conf.d/" does not exist on Ubuntu 26.04 LTS because of migration from initramfs-tools to Dracut, resulting error during the postinst phase.

This line was added in 16fff63ceabb401128a1a6937343abf88f5f6ba0, which means it doesn't exist in the plymouth-theme code of upstream Ubuntu. So removing this line should be fine.

### Checklist
- [x] `debuild -us -uc` succeeds
- [x] Installation of generated .deb file succeeds

```
root@7dcb9f444928:/workdir# apt install ../*.deb
Note, selecting 'plymouth-theme-elementary' instead of '../plymouth-theme-elementary_6.0.0_all.deb'
Installing:
  plymouth-theme-elementary

Installing dependencies:
  fonts-ubuntu  libkmod2  libplymouth5  plymouth  plymouth-label  plymouth-theme-spinner  systemd-hwe-hwdb  udev

Suggested packages:
  desktop-base  plymouth-themes

Summary:
  Upgrading: 0, Installing: 9, Removing: 0, Not Upgrading: 0
  Download size: 3086 kB / 3163 kB
  Space needed: 17.6 MB / 148 GB available

Continue? [Y/n] y
Get:1 /plymouth-theme-elementary_6.0.0_all.deb plymouth-theme-elementary all 6.0.0 [77.3 kB]
Get:2 http://archive.ubuntu.com/ubuntu resolute/main amd64 libkmod2 amd64 34.2-2ubuntu2 [50.9 kB]
Get:3 http://archive.ubuntu.com/ubuntu resolute/main amd64 udev amd64 259.5-0ubuntu3 [1501 kB]
Get:4 http://archive.ubuntu.com/ubuntu resolute/main amd64 systemd-hwe-hwdb all 259.5.3ubuntu [3384 B]
Get:5 http://archive.ubuntu.com/ubuntu resolute/main amd64 libplymouth5 amd64 24.004.60+git20250831.4a3c171d-0ubuntu8 [137 kB]
Get:6 http://archive.ubuntu.com/ubuntu resolute/main amd64 plymouth amd64 24.004.60+git20250831.4a3c171d-0ubuntu8 [135 kB]
Get:7 http://archive.ubuntu.com/ubuntu resolute/main amd64 fonts-ubuntu all 0.869+git20240321-0ubuntu2 [1077 kB]
Get:8 http://archive.ubuntu.com/ubuntu resolute/main amd64 plymouth-label amd64 24.004.60+git20250831.4a3c171d-0ubuntu8 [9602 B]
Get:9 http://archive.ubuntu.com/ubuntu resolute/main amd64 plymouth-theme-spinner amd64 24.004.60+git20250831.4a3c171d-0ubuntu8 [173 kB]
Fetched 3086 kB in 0s (6532 kB/s)
Selecting previously unselected package libkmod2:amd64.
(Reading database ... 54405 files and directories currently installed.)
Preparing to unpack .../0-libkmod2_34.2-2ubuntu2_amd64.deb ...
Unpacking libkmod2:amd64 (34.2-2ubuntu2) ...
Selecting previously unselected package udev.
Preparing to unpack .../1-udev_259.5-0ubuntu3_amd64.deb ...
Unpacking udev (259.5-0ubuntu3) ...
Selecting previously unselected package systemd-hwe-hwdb.
Preparing to unpack .../2-systemd-hwe-hwdb_259.5.3ubuntu_all.deb ...
Unpacking systemd-hwe-hwdb (259.5.3ubuntu) ...
Selecting previously unselected package libplymouth5:amd64.
Preparing to unpack .../3-libplymouth5_24.004.60+git20250831.4a3c171d-0ubuntu8_amd64.deb ...
Unpacking libplymouth5:amd64 (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Selecting previously unselected package plymouth.
Preparing to unpack .../4-plymouth_24.004.60+git20250831.4a3c171d-0ubuntu8_amd64.deb ...
Unpacking plymouth (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Selecting previously unselected package fonts-ubuntu.
Preparing to unpack .../5-fonts-ubuntu_0.869+git20240321-0ubuntu2_all.deb ...
Unpacking fonts-ubuntu (0.869+git20240321-0ubuntu2) ...
Selecting previously unselected package plymouth-label.
Preparing to unpack .../6-plymouth-label_24.004.60+git20250831.4a3c171d-0ubuntu8_amd64.deb ...
Unpacking plymouth-label (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Selecting previously unselected package plymouth-theme-spinner.
Preparing to unpack .../7-plymouth-theme-spinner_24.004.60+git20250831.4a3c171d-0ubuntu8_amd64.deb ...
Unpacking plymouth-theme-spinner (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Selecting previously unselected package plymouth-theme-elementary.
Preparing to unpack .../8-plymouth-theme-elementary_6.0.0_all.deb ...
Unpacking plymouth-theme-elementary (6.0.0) ...
Setting up fonts-ubuntu (0.869+git20240321-0ubuntu2) ...
Setting up libplymouth5:amd64 (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Setting up libkmod2:amd64 (34.2-2ubuntu2) ...
Setting up udev (259.5-0ubuntu3) ...
Creating group 'input' with GID 995.
Creating group 'sgx' with GID 994.
Creating group 'clock' with GID 993.
Creating group 'kvm' with GID 992.
Creating group 'render' with GID 991.
Setting up systemd-hwe-hwdb (259.5.3ubuntu) ...
Setting up plymouth (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Setting up plymouth-label (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
Setting up plymouth-theme-spinner (24.004.60+git20250831.4a3c171d-0ubuntu8) ...
update-alternatives: using /usr/share/plymouth/themes/bgrt/bgrt.plymouth to provide /usr/share/plymouth/themes/default.plymouth (default.plymouth) in auto mode
Setting up plymouth-theme-elementary (6.0.0) ...
update-alternatives: using /usr/share/plymouth/themes/elementary/elementary.plymouth to provide /usr/share/plymouth/themes/default.plymouth (default.plymouth) in auto mode
Processing triggers for libc-bin (2.43-2ubuntu2) ...
Processing triggers for man-db (2.13.1-1build1) ...
Processing triggers for fontconfig (2.17.1-3ubuntu1) ...
root@7dcb9f444928:/workdir#
```