### PR TITLE
Add debian/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,30 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: plymouth-theme-elementary
+Upstream-Contact: builds@elementary.io
+Source: https://github.com/elementary/plymouth-theme
+
+Files: *
+Copyright: 2012-2026 elementary <builds@elementary.io>
+License: GPL-3.0+
+
+Files: debian/*
+Copyright: 2012-2026 elementary <builds@elementary.io>
+           2009-2012 Daniel Baumann <mail@daniel-baumann.ch>
+License: GPL-3.0+
+
+License: GPL-3.0+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".


### PR DESCRIPTION
As I mentioned in https://github.com/elementary/plymouth-theme/pull/33#issuecomment-4526898422

The code in this repository was originally imported from `plymouth-theme-ubuntu-logo` package of Ubuntu 12.04 LTS in e168d936ad05b9c9618c907cf1be658c3e73eda8 so I also credited Daniel Baumann that was in the copyright file of plymouth source package:

```
ryonakano@fedora-host:~/work/tmp/plymouth (ubuntu/resolute =)$ grep -A2 -F "Files: debian/*" debian/copyright
Files: debian/*
Copyright: 2009-2014 Daniel Baumann <mail@daniel-baumann.ch>
License: GPL-2+
ryonakano@fedora-host:~/work/tmp/plymouth (ubuntu/resolute =)$
```
